### PR TITLE
Enhance coach management with update and accept features

### DIFF
--- a/src/api/roles/coach/coach.py
+++ b/src/api/roles/coach/coach.py
@@ -68,7 +68,7 @@ def create_coach_request(coach_details: CoachRequestInput, db = Depends(get_sess
 
 # Updating coach request , which includes coach availability, experience, and certifications.
 @router.patch("/update_coach_info", response_model=UpdateCoachInfoResponse)
-def update_coach_request(new_coach_details: UpdateCoachInfoInput, db = Depends(get_session), coach_acc: Account = Depends(get_coach_account)):
+def update_coach_info(new_coach_details: UpdateCoachInfoInput, db = Depends(get_session), coach_acc: Account = Depends(get_coach_account)):
     """
     Updates coach request information, including certifications, experiences, and availability
     Deletes existing certs, exps, and availabilities and replaces with new ones if the user provides them, otherwise leaves them as is

--- a/src/api/roles/coach/coach.py
+++ b/src/api/roles/coach/coach.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, HTTPException, Depends
-from src.api.roles.coach.domain import CreateCoachRequestResponse, UpdateCoachInfoResponse, CoachRequestDeniedResponse, AcceptedClientResponse
-from src.api.dependencies import get_coach_account, get_client_account
+from src.api.roles.coach.domain import CreateCoachRequestResponse, UpdateCoachInfoResponse, CoachRequestDeniedResponse, AcceptedClientResponse, WorkoutPlanInput
+from src.api.dependencies import get_coach_account, get_client_account, get_admin_account
 
 #models
-from src.api.roles.coach.domain import CoachRequestInput, CoachAccountResponse, DunderResponse, UpdateCoachInfoInput, ClientCoachRequestInput
+from src.api.roles.coach.domain import CoachDeniedRequestInput, CoachRequestInput, CoachAccountResponse, DunderResponse, UpdateCoachInfoInput, ClientCoachRequestInput, WorkoutInput, WorkoutActivityInput
 
-
+from src.database.workouts_and_activities.models import Workout, WorkoutEquiptment, WorkoutActivity, WorkoutPlan, WorkoutPlanActivity
 from src.database.coach_client_relationship.models import ClientCoachRequest
 from src.database.session import get_session
 from src.database.account.models import Account, Availability
@@ -109,21 +109,22 @@ def update_coach_info(new_coach_details: UpdateCoachInfoInput, db = Depends(get_
     return UpdateCoachInfoResponse(coach_id=coach.id) # type: ignore
 
 @router.delete("/coach_request_denied", response_model=CoachRequestDeniedResponse)
-def coach_request_denied(db = Depends(get_session), acc: Account = Depends(get_coach_account)):
+def coach_request_denied(coach_request_info :CoachDeniedRequestInput, db = Depends(get_session), acc: Account = Depends(get_admin_account)):
     """
     Deletes coach request, coach record, certs, exps, and avails, and sets user account coach_id to null
     Errors when user does not have a coach_id
     """
-    if acc.coach_id is None:
-        raise HTTPException(404, detail="No coach profile found for this account")
+    if acc.admin_id is None:
+        raise HTTPException(404, detail="You must be an admin to perform this action")
     
-    db.query(Coach).filter(Coach.id == acc.coach_id).delete(synchronize_session=False)
+    
 
-    acc.coach_id = None
+    db.query(Coach).filter(Coach.id == coach_request_info.coach_id).delete(synchronize_session=False)
+    db.query(CoachRequest).filter(CoachRequest.coach_id == coach_request_info.coach_id).delete(synchronize_session=False)
     
     db.commit()
 
-    return CoachRequestDeniedResponse(coach_id=acc.coach_id) # type: ignore
+    return CoachRequestDeniedResponse(coach_id=None) # type: ignore
 
 @router.post("/me", response_model=CoachAccountResponse)
 def me(db = Depends(get_session), acc: Account = Depends(get_coach_account)):
@@ -131,6 +132,85 @@ def me(db = Depends(get_session), acc: Account = Depends(get_coach_account)):
         base_account=acc,
         coach_account=db.get(Coach, acc.coach_id)
     )
+
+@router.post("/create_workout", response_model=DunderResponse)
+def create_workout(workout_details: WorkoutInput, db = Depends(get_session), acc: Account = Depends(get_coach_account)):
+    """
+    Creates a workout and attaches equiptment if provided
+    Errors when user does not have a coach_id
+    """
+    if acc.coach_id is None:
+        raise HTTPException(404, detail="No coach profile found for this account")
+    
+    workout = Workout(
+        name=workout_details.name,
+        description=workout_details.description,
+        instructions=workout_details.instructions,
+        workout_type=workout_details.workout_type
+    )
+
+    db.add(workout)
+    db.flush()
+
+    if workout_details.equipment is not None:
+        for e in workout_details.equipment:
+            db.add(e)
+            db.flush()
+            db.add(WorkoutEquiptment(workout_id=workout.id, equiptment_id=e.id)) # type: ignore
+
+    db.commit()
+
+    return DunderResponse()
+
+
+@router.post("/create_workout_activity", response_model=DunderResponse)
+def create_workout_activity(activity_details: WorkoutActivityInput, db = Depends(get_session), acc: Account = Depends(get_coach_account)):
+    """
+    Creates a workout activity and attaches it to a workout
+    Errors when user does not have a coach_id
+    """
+    if acc.coach_id is None:
+        raise HTTPException(404, detail="No coach profile found for this account")
+
+    activity = WorkoutActivity(
+        workout_id=activity_details.workout_id,
+        intensity_measure=activity_details.intensity_measure,
+        intensity_value=activity_details.intensity_value,
+        estimated_calories_per_unit_frequency=activity_details.estimated_calories_per_unit_frequency
+    )
+
+    db.add(activity)
+    db.flush()
+    db.commit()
+
+    return DunderResponse()
+
+@router.post("/create_workout_plan", response_model=DunderResponse)
+def create_workout_plan(plan_details: WorkoutPlanInput, db = Depends(get_session), acc: Account = Depends(get_coach_account)):
+    """
+    Creates a workout plan and attaches workout activities if provided
+    Errors when user does not have a coach_id
+    """
+    if acc.coach_id is None:
+        raise HTTPException(404, detail="No coach profile found for this account")
+
+    plan = WorkoutPlan(
+        strata_name=plan_details.strata_name
+    )
+
+    db.add(plan)
+    db.flush()
+
+    if plan_details.workout_activities is not None:
+        for activity in plan_details.workout_activities:
+            db.add(activity)
+            db.flush()
+            db.add(WorkoutPlanActivity(workout_plan_id=plan.id, workout_activity_id=activity.id)) # type: ignore
+
+    db.commit()
+
+    return DunderResponse()
+
 
 @router.post("/accept_client_request", response_model=AcceptedClientResponse)
 def accept_client_request(request_input : ClientCoachRequestInput, db = Depends(get_session), acc: Account = Depends(get_client_account)):

--- a/src/api/roles/coach/coach.py
+++ b/src/api/roles/coach/coach.py
@@ -1,10 +1,13 @@
+from datetime import date
+
 from fastapi import APIRouter, HTTPException, Depends
-from src.api.roles.coach.domain import CreateCoachRequestResponse, UpdateCoachInfoResponse, CoachRequestDeniedResponse, AcceptedClientResponse, WorkoutPlanInput
+from src.api.roles.coach.domain import CoachAvailabilityResponse, CreateCoachRequestResponse, UpdateCoachInfoResponse, CoachRequestDeniedResponse, AcceptedClientResponse, WorkoutPlanInput
 from src.api.dependencies import get_coach_account, get_client_account, get_admin_account
 
 #models
 from src.api.roles.coach.domain import CoachDeniedRequestInput, CoachRequestInput, CoachAccountResponse, DunderResponse, UpdateCoachInfoInput, ClientCoachRequestInput, WorkoutInput, WorkoutActivityInput
 
+from src.database import coach
 from src.database.workouts_and_activities.models import Workout, WorkoutEquiptment, WorkoutActivity, WorkoutPlan, WorkoutPlanActivity
 from src.database.coach_client_relationship.models import ClientCoachRequest
 from src.database.session import get_session
@@ -210,6 +213,25 @@ def create_workout_plan(plan_details: WorkoutPlanInput, db = Depends(get_session
     db.commit()
 
     return DunderResponse()
+
+@router.get("/coach_availability/{coach_id}", response_model=CoachAvailabilityResponse)
+def get_coach_availability(coach_id: int, db = Depends(get_session), acc: Account = Depends(get_client_account)):
+    """
+    Gets coach availability for a given coach
+    """
+    if acc.client_id is None:
+        raise HTTPException(404, detail="Please log in to view coach availability")
+    
+    coach = db.get(Coach, coach_id)
+    if coach is None:
+        raise HTTPException(404, detail="Coach not found")
+    
+    if coach.verified == False:
+        raise HTTPException(404, detail="Coach is not verified yet, availability is not viewable")
+    
+    availabilities = db.query(Availability).filter(Availability.coach_availability_id == coach.coach_availability).all()
+
+    return CoachAvailabilityResponse(coach_availabilities=availabilities)
 
 
 @router.post("/accept_client_request", response_model=AcceptedClientResponse)

--- a/src/api/roles/coach/coach.py
+++ b/src/api/roles/coach/coach.py
@@ -123,7 +123,7 @@ def coach_request_denied(db = Depends(get_session), acc: Account = Depends(get_c
     
     db.commit()
 
-    return CoachRequestDeniedResponse(coach_request_id=cr.id, coach_id=acc.coach_id) # type: ignore
+    return CoachRequestDeniedResponse(coach_id=acc.coach_id) # type: ignore
 
 @router.post("/me", response_model=CoachAccountResponse)
 def me(db = Depends(get_session), acc: Account = Depends(get_coach_account)):

--- a/src/api/roles/coach/coach.py
+++ b/src/api/roles/coach/coach.py
@@ -1,14 +1,15 @@
 from fastapi import APIRouter, HTTPException, Depends
-from src.api.roles.coach.domain import CreateCoachRequestResponse
+from src.api.roles.coach.domain import CreateCoachRequestResponse, UpdateCoachInfoResponse, CoachRequestDeniedResponse, AcceptedClientResponse
 from src.api.dependencies import get_coach_account, get_client_account
 
 #models
-from src.api.roles.coach.domain import CoachRequestInput, CoachAccountResponse
+from src.api.roles.coach.domain import CoachRequestInput, CoachAccountResponse, DunderResponse, UpdateCoachInfoInput, ClientCoachRequestInput
 
 
+from src.database.coach_client_relationship.models import ClientCoachRequest
 from src.database.session import get_session
-from src.database.account.models import Account
-from src.database.coach.models import Coach, CoachCertifications, CoachExperience, CoachAvailability
+from src.database.account.models import Account, Availability
+from src.database.coach.models import Coach, CoachCertifications, CoachExperience, CoachAvailability, Experience, Certifications
 from src.database.role_management.models import CoachRequest
 
 router = APIRouter(prefix="/roles/coach", tags=["coach"])
@@ -65,9 +66,83 @@ def create_coach_request(coach_details: CoachRequestInput, db = Depends(get_sess
 
     return CreateCoachRequestResponse(coach_request_id=cr.id, coach_id=coach.id) # type: ignore
 
+# Updating coach request , which includes coach availability, experience, and certifications.
+@router.patch("/update_coach_info", response_model=UpdateCoachInfoResponse)
+def update_coach_request(new_coach_details: UpdateCoachInfoInput, db = Depends(get_session), coach_acc: Coach = Depends(get_coach_account)):
+    """
+    Updates coach request information, including certifications, experiences, and availability
+    Deletes existing certs, exps, and availabilities and replaces with new ones if the user provides them, otherwise leaves them as is
+    Errors when user does not have a coach_id
+    """
+    if coach_acc.id is None:
+        raise HTTPException(404, detail="No coach profile found for this account")
+    
+    coach_availability_id = db.query(CoachAvailability.id).filter(CoachAvailability.id == coach_acc.coach_availability).first()
+    coach_certifications_id = db.query(CoachCertifications.certification_id).filter(CoachCertifications.coach_id == coach_acc.id).all()
+    coach_experiences_id = db.query(CoachExperience.experience_id).filter(CoachExperience.coach_id == coach_acc.id).all()
+
+    if new_coach_details.availabilities is not None:
+        db.query(Availability).filter(Availability.coach_availability_id == coach_availability_id).delete(synchronize_session=False)
+        for a in new_coach_details.availabilities:
+            a.coach_availability_id = coach_availability_id # type: ignore
+            db.add(a)
+
+    if new_coach_details.certifications is not None:
+        db.query(CoachCertifications).filter(Certifications.id == coach_certifications_id).delete(synchronize_session=False)
+        for c in new_coach_details.certifications:
+            db.add(CoachCertifications(coach_id=coach.id, certification_id=c.id)) # type: ignore
+    
+    if new_coach_details.experiences is not None:
+        db.query(CoachExperience).filter(Experience.id == coach_experiences_id).delete(synchronize_session=False)
+        for e in new_coach_details.experiences:
+            db.add(CoachExperience(coach_id=coach.id, experience_id=e.id)) # type: ignore
+
+    db.flush()
+    db.commit()
+
+    return UpdateCoachInfoResponse(coach_request_id=cr.id, coach_id=coach_acc.id) # type: ignore
+
+@router.delete("/coach_request_denied", response_model=CoachRequestDeniedResponse)
+def coach_request_denied(db = Depends(get_session), acc: Account = Depends(get_coach_account)):
+    """
+    Deletes coach request, coach record, certs, exps, and avails, and sets user account coach_id to null
+    Errors when user does not have a coach_id
+    """
+    if acc.coach_id is None:
+        raise HTTPException(404, detail="No coach profile found for this account")
+    
+    db.query(Coach).filter(Coach.id == acc.coach_id).delete(synchronize_session=False)
+
+    acc.coach_id = None
+    
+    db.commit()
+
+    return CoachRequestDeniedResponse(coach_request_id=cr.id, coach_id=acc.coach_id) # type: ignore
+
 @router.post("/me", response_model=CoachAccountResponse)
 def me(db = Depends(get_session), acc: Account = Depends(get_coach_account)):
     return CoachAccountResponse(
         base_account=acc,
         coach_account=db.get(Coach, acc.coach_id)
     )
+
+@router.post("/accept_client_request", response_model=AcceptedClientResponse)
+def accept_client_request(request_input : ClientCoachRequestInput, db = Depends(get_session), acc: Account = Depends(get_client_account)):
+    """
+    Accepts a client coach request, creates a client coach relationship row
+    Errors when client coach request is not found, or if the request is not for a coach_id that matches the current user's coach_id
+
+    """
+    request = db.query(ClientCoachRequest).filter(ClientCoachRequest.id == request_input.id).first()
+    if request is None:
+        raise HTTPException(404, detail="Client coach request not found")
+    
+    if request.coach_id != acc.coach_id:
+        raise HTTPException(403, detail="You are not the owner of this coach request")
+    
+    if request_input.is_accepted:
+        request.is_accepted = True
+        db.add(ClientCoachRequest(is_accepted = request.is_accepted, client_id = request.client_id, coach_id = request.coach_id)) # type: ignore
+        db.flush()
+
+        return AcceptedClientResponse(client_coach_request_id=request.id, client_id=request.client_id, coach_id=request.coach_id) # type: ignore

--- a/src/api/roles/coach/coach.py
+++ b/src/api/roles/coach/coach.py
@@ -68,19 +68,19 @@ def create_coach_request(coach_details: CoachRequestInput, db = Depends(get_sess
 
 # Updating coach request , which includes coach availability, experience, and certifications.
 @router.patch("/update_coach_info", response_model=UpdateCoachInfoResponse)
-def update_coach_request(new_coach_details: UpdateCoachInfoInput, db = Depends(get_session), coach_acc: Coach = Depends(get_coach_account)):
+def update_coach_request(new_coach_details: UpdateCoachInfoInput, db = Depends(get_session), coach_acc: Account = Depends(get_coach_account)):
     """
     Updates coach request information, including certifications, experiences, and availability
     Deletes existing certs, exps, and availabilities and replaces with new ones if the user provides them, otherwise leaves them as is
     Errors when user does not have a coach_id
     """
+    
     if coach_acc.id is None:
         raise HTTPException(404, detail="No coach profile found for this account")
     
-    coach_availability_id = db.query(CoachAvailability.id).filter(CoachAvailability.id == coach_acc.coach_availability).first()
-    coach_certifications_id = db.query(CoachCertifications.certification_id).filter(CoachCertifications.coach_id == coach_acc.id).all()
-    coach_experiences_id = db.query(CoachExperience.experience_id).filter(CoachExperience.coach_id == coach_acc.id).all()
+    coach = db.get(Coach, coach_acc.coach_id)
 
+    coach_availability_id = db.query(CoachAvailability.id).filter(CoachAvailability.id == coach.coach_availability).scalar()
     if new_coach_details.availabilities is not None:
         db.query(Availability).filter(Availability.coach_availability_id == coach_availability_id).delete(synchronize_session=False)
         for a in new_coach_details.availabilities:
@@ -88,19 +88,25 @@ def update_coach_request(new_coach_details: UpdateCoachInfoInput, db = Depends(g
             db.add(a)
 
     if new_coach_details.certifications is not None:
-        db.query(CoachCertifications).filter(Certifications.id == coach_certifications_id).delete(synchronize_session=False)
+        db.query(CoachCertifications).filter(CoachCertifications.coach_id == coach.id).delete(synchronize_session=False)
+        for c in new_coach_details.certifications:
+            db.add(c)
+        db.flush()
         for c in new_coach_details.certifications:
             db.add(CoachCertifications(coach_id=coach.id, certification_id=c.id)) # type: ignore
-    
+
     if new_coach_details.experiences is not None:
-        db.query(CoachExperience).filter(Experience.id == coach_experiences_id).delete(synchronize_session=False)
+        db.query(CoachExperience).filter(CoachExperience.coach_id == coach.id).delete(synchronize_session=False)
+        for e in new_coach_details.experiences:
+            db.add(e)
+        db.flush()
         for e in new_coach_details.experiences:
             db.add(CoachExperience(coach_id=coach.id, experience_id=e.id)) # type: ignore
 
     db.flush()
     db.commit()
 
-    return UpdateCoachInfoResponse(coach_request_id=cr.id, coach_id=coach_acc.id) # type: ignore
+    return UpdateCoachInfoResponse(coach_id=coach.id) # type: ignore
 
 @router.delete("/coach_request_denied", response_model=CoachRequestDeniedResponse)
 def coach_request_denied(db = Depends(get_session), acc: Account = Depends(get_coach_account)):

--- a/src/api/roles/coach/domain.py
+++ b/src/api/roles/coach/domain.py
@@ -1,10 +1,7 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 from typing import List, Optional
+from fastapi import HTTPException
 
-class CreateCoachRequestResponse(BaseModel):
-    #coach row created, attatched to user account, but has verified=False
-    coach_request_id: int
-    coach_id: int
 
 #Coach
 from src.database.coach.models import Experience, Certifications, Coach
@@ -14,6 +11,44 @@ class CoachRequestInput(BaseModel): #used for CRUD, mapping layer doesn't concer
     experiences: List[Experience]
     certifications: List[Certifications]
 
+class UpdateCoachInfoInput(BaseModel):
+    availabilities: Optional[List[Availability]] = Field(default=None)
+    experiences: Optional[List[Experience]] = Field(default=None)
+    certifications: Optional[List[Certifications]] = Field(default=None)
+
+class ClientCoachRequestInput(BaseModel):
+    id: int
+    is_accepted: bool
+    client_id: int
+    coach_id: int
+
+
+#Responses
+class DunderResponse(BaseModel):
+    details: str = "success"
+
+
 class CoachAccountResponse(BaseModel):
     base_account: Account
     coach_account: Coach
+
+class CreateCoachRequestResponse(BaseModel):
+    #coach row created, attatched to user account, but has verified=False
+    coach_request_id: int
+    coach_id: int
+
+class UpdateCoachInfoResponse(BaseModel):
+    #coach row updated with new certs, exps, and avails, but still has verified=False
+    coach_request_id: int
+    coach_id: int
+
+class CoachRequestDeniedResponse(BaseModel):
+    #coach row deleted along with certs, exps, and avails, user account set to coach_id=null
+    coach_request_id: int
+    coach_id: int
+
+class AcceptedClientResponse(BaseModel):
+    #client request accepted, row added to client_coach_relationship
+    client_coach_request_id: int
+    client_id: int
+    coach_id: int

--- a/src/api/roles/coach/domain.py
+++ b/src/api/roles/coach/domain.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from pydantic import BaseModel, Field, model_validator
 from typing import List, Optional
 from fastapi import HTTPException
@@ -6,6 +8,7 @@ from fastapi import HTTPException
 #Coach
 from src.database.coach.models import Experience, Certifications, Coach
 from src.database.account.models import Availability, Account
+from src.database.workouts_and_activities.models import Equiptment, WorkoutPlanActivity, WorkoutType
 class CoachRequestInput(BaseModel): #used for CRUD, mapping layer doesn't concern with mapping data->entities
     availabilities: List[Availability]
     experiences: List[Experience]
@@ -22,6 +25,27 @@ class ClientCoachRequestInput(BaseModel):
     client_id: int
     coach_id: int
 
+class CoachDeniedRequestInput(BaseModel):
+    coach_id: int
+    is_accepted: bool = False
+
+class WorkoutInput(BaseModel):
+    name: str
+    description: str
+    instructions: str
+    workout_type: WorkoutType
+    equipment: Optional[List[Equiptment]]
+
+class WorkoutActivityInput(BaseModel):
+    workout_id: int
+    intensity_measure: Optional[str] = None
+    intensity_value: Optional[int] = None
+    estimated_calories_per_unit_frequency: Decimal = Field(max_digits=10, decimal_places=6)
+
+
+class WorkoutPlanInput(BaseModel):
+    strata_name: str
+    workout_activities: Optional[List[WorkoutPlanActivity]] = Field(default=None)
 
 #Responses
 class DunderResponse(BaseModel):

--- a/src/api/roles/coach/domain.py
+++ b/src/api/roles/coach/domain.py
@@ -7,7 +7,7 @@ from fastapi import HTTPException
 
 #Coach
 from src.database.coach.models import Experience, Certifications, Coach
-from src.database.account.models import Availability, Account
+from src.database.account.models import Availability, Account, Weekday
 from src.database.workouts_and_activities.models import Equiptment, WorkoutPlanActivity, WorkoutType
 class CoachRequestInput(BaseModel): #used for CRUD, mapping layer doesn't concern with mapping data->entities
     availabilities: List[Availability]
@@ -42,7 +42,6 @@ class WorkoutActivityInput(BaseModel):
     intensity_value: Optional[int] = None
     estimated_calories_per_unit_frequency: Decimal = Field(max_digits=10, decimal_places=6)
 
-
 class WorkoutPlanInput(BaseModel):
     strata_name: str
     workout_activities: Optional[List[WorkoutPlanActivity]] = Field(default=None)
@@ -69,6 +68,9 @@ class CoachRequestDeniedResponse(BaseModel):
     #coach row deleted along with certs, exps, and avails, user account set to coach_id=null
     coach_request_id: int
     coach_id: int
+
+class CoachAvailabilityResponse(BaseModel):
+    coach_availabilities: List[Availability]
 
 class AcceptedClientResponse(BaseModel):
     #client request accepted, row added to client_coach_relationship

--- a/src/api/roles/coach/domain.py
+++ b/src/api/roles/coach/domain.py
@@ -39,7 +39,6 @@ class CreateCoachRequestResponse(BaseModel):
 
 class UpdateCoachInfoResponse(BaseModel):
     #coach row updated with new certs, exps, and avails, but still has verified=False
-    coach_request_id: int
     coach_id: int
 
 class CoachRequestDeniedResponse(BaseModel):

--- a/tests/payload_tools/coach.py
+++ b/tests/payload_tools/coach.py
@@ -30,3 +30,36 @@ def build_coach_request_payload(weekday="tuesday"):
             }
         ],
     }
+
+def build_update_coach_info_payload(weekday="wednesday"):
+    """
+    Builds a mock payload for updating coach information, which includes certifications, experiences, and availability.
+    """
+    return {
+        "availabilities": [
+            {
+                "weekday": weekday,
+                "start_time": "19:00:00",
+                "end_time": "21:00:00",
+            }
+        ],
+        "experiences": [
+            {
+                "experience_name": "Group Fitness Instructor",
+                "experience_title": "Lead Instructor",
+                "experience_description": "Led group fitness classes for 2 years.",
+                "experience_start": "2021-01-01",
+                "experience_end": "2023-01-01",
+            }
+        ],
+        "certifications": [
+            {
+                "certification_name": "Advanced Coaching Certificate",
+                "certification_title": "Level 2",
+                "certification_description": "Advanced coaching certification.",
+                "certification_date": "2024-06-01",
+                "certification_score": "A+",
+                "certification_organization": "Test Institute",
+            }
+        ],
+    }

--- a/tests/test_coach.py
+++ b/tests/test_coach.py
@@ -1,4 +1,4 @@
-from tests.payload_tools.coach import build_coach_request_payload
+from tests.payload_tools.coach import build_coach_request_payload, build_update_coach_info_payload
 
 def test_coach_request_flow(test_client, client_auth_header):
     """
@@ -18,6 +18,23 @@ def test_coach_request_flow(test_client, client_auth_header):
     assert "coach_id" in coach_request_data
     assert "coach_request_id" in coach_request_data
 
+def test_coach_update_info_flow(test_client, coach_auth_header):
+    """
+    Test updating Coach information after a Coach Request has been created. Uses coach_auth_header, which promotes a user all the way to a Coach role.
+    """
+    update_coach_info_payload = build_update_coach_info_payload()
+
+    update_info_response = test_client.patch(
+        "/roles/coach/update_coach_info",
+        json=update_coach_info_payload,
+        headers=coach_auth_header,
+    )
+
+    assert update_info_response.status_code == 200
+    update_info_data = update_info_response.json()
+    assert "coach_id" in update_info_data
+
+    
 def test_coach_me_endpoint(test_client, coach_auth_header):
     """
     Test that a registered coach can fetch their coach profile details via the /me endpoint.


### PR DESCRIPTION
Added functionality to update coach information, accept client requests, and handle coach request denial. This includes new endpoints for updating coach details and managing client-coach relationships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coaches can update profile details (availability, certifications, experiences).
  * Coaches can decline a coaching request.
  * Coaches can accept and confirm client requests with relationship details.

* **Tests**
  * Added an automated test and test payload helper covering the coach update flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->