### PR TITLE
Change uvicorn.run host to '0.0.0.0'

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -23,4 +23,4 @@ def read_current_account(user = Depends(get_account_from_bearer)):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, port=9090)    
+    uvicorn.run(app, host="0.0.0.0", port=9090)    


### PR DESCRIPTION
Updated the host parameter in uvicorn.run to allow access from any IP address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API server configuration to bind to all available network interfaces on port 9090.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->